### PR TITLE
ログイン時とログアウト時のヘッダーの表示分け

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,7 +12,11 @@
 
   <body class="flex flex-col min-h-screen bg-primary text-text-color">
     <div class="flex-grow">
-      <%= render 'shared/header' %>
+      <% if logged_in? %>
+        <%= render 'shared/header' %>
+      <% else %>
+        <%= render 'shared/before_login_header' %>
+      <% end %>
       <%= yield %>
     </div>
   </body>

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -8,7 +8,12 @@
     <ul class="menu menu-horizontal space-x-4">
       <li>
         <button class="btn btn-neutral bg-base-100 text-secondary">
-          <%= link_to "ログアウト", logout_path, class: "nav-link", data: { turbo_method: :delete }%>
+          <%= link_to "ログイン", login_path, class: "nav-link"%>
+        </button>
+      </li>
+      <li>
+        <button class="btn btn-neutral bg-base-100 text-secondary">
+          <%= link_to "新規登録", new_user_path, class: "nav-link"%>
         </button>
       </li>
     </ul>


### PR DESCRIPTION
# 概要
ログイン時とログアウト時のヘッダーの表示分け

## 実装内容
- ログイン中のヘッダーのビューを作成（ログアウトボタン）
- ログイン時とログアウト時でヘッダーの表示を分ける条件を追加

## 達成条件
- [x] ログイン中は「ログアウト」ボタンのあるヘッダーが表示される
- [x]  ログアウト中は「新規登録」ボタンと「ログイン」ボタンのあるヘッダーが表示される

## 備考
### 実装メモ
[Notion](https://www.notion.so/44d57852419e4daab4cd9db4f076db94?pvs=4)
### 画面イメージ
[![Image from Gyazo](https://i.gyazo.com/37eb9024660401abba45e9dd66d10c52.gif)](https://gyazo.com/37eb9024660401abba45e9dd66d10c52)

closed #24 