### PR TITLE
初期化した地図の表示_やり直し

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,9 @@ gem "bootsnap", require: false
 # ユーザー登録・ログイン・ログアウト
 gem 'sorcery', '0.16.3'
 
+# 環境変数の管理
+gem'dotenv-rails'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,6 +103,10 @@ GEM
     debug (1.9.2)
       irb (~> 1.10)
       reline (>= 0.3.8)
+    dotenv (3.1.2)
+    dotenv-rails (3.1.2)
+      dotenv (= 3.1.2)
+      railties (>= 6.1)
     drb (2.2.1)
     erubi (1.13.0)
     faraday (2.10.0)
@@ -321,6 +325,7 @@ DEPENDENCIES
   capybara
   cssbundling-rails
   debug
+  dotenv-rails
   jbuilder
   jsbundling-rails
   pg (~> 1.1)

--- a/app/views/routes/show.html.erb
+++ b/app/views/routes/show.html.erb
@@ -1,5 +1,5 @@
 <div class="flex flex-col justify-stretch p-10">
-  <div class="p-10 bg-base-100 rounded-lg text-secondary">
+  <div class="p-10 bg-base-100 rounded-lg text-secondary">へんしゅ
     <h2 class="text-2xl font-semibold text-text-color mb-8">比較結果</h2>
 
     <div class="flex flex-row">
@@ -15,21 +15,41 @@
       <p class="text-base">までの距離と同じくらい！！</p>
     </div>
 
+    <script src="https://maps.googleapis.com/maps/api/js?key=<%= "#{ENV['MAPS_JAVASCRIPT_API']}" %>&language=ja&callback=initMap" async defer></script>
+
     <div class="m-5 px-5">
       <div class="flex flex-row bg-primary rounded-lg text-secondary">
         <%# 基準ルートの地図を表示 %>
-        <div class="flex flex-row mb-3 p-5">
-          <div class="flex flex-col">
-            <p class="text-base font-bold">基準ルート</p>
-            <%= image_tag 'map_sample.png' %>
-          </div>
+        <div class="flex flex-col w-1/2 m-3 p-3 bg-white">
+          <p class="text-base font-bold mb-2">基準ルート</p>
+
+          <div id="map1" style="height: 400px; width: 100%;"></div>
+
+          <script>
+            function initMap() {
+              var MyLatLng1 = new google.maps.LatLng(35.6811673, 139.7670516);
+              var Options1 = {
+                zoom: 13,
+                center: MyLatLng1,
+                mapTypeId: 'roadmap'
+              };
+              var map1 = new google.maps.Map(document.getElementById('map1'), Options1);
+
+              var MyLatLng2 = new google.maps.LatLng(33.59344097007448, 130.35152609126914);
+              var Options2 = {
+                zoom: 13,
+                center: MyLatLng2,
+                mapTypeId: 'roadmap'
+              };
+              var map2 = new google.maps.Map(document.getElementById('map2'), Options2);
+            }
+          </script>
         </div>
+
         <%# 比較ルートの地図を表示 %>
-        <div class="flex flex-row mb-3 p-5">
-          <div class="flex flex-col">
-            <p class="text-base font-bold">比較ルート</p>
-            <%= image_tag 'map_sample.png' %>
-          </div>
+        <div class="flex flex-col w-1/2 m-3 p-3 bg-white">
+          <p class="text-base font-bold mb-2">比較ルート</p>
+          <div id="map2" style="height: 400px; width: 100%;"></div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
# 概要
初期化した地図の表示のプルリク内容について、不備があったため訂正と追加

## 不備箇所
- 環境変数の設定がされていなかったため、APIキーが公開されている状態であった
- 上記の問題については下記の対応を行った。
  - APIキーの再生成をし、公開されたキーによる悪用を防いだ
  - APIキーに環境変数を設定した

## 実装内容
- 環境変数関係の設定
    - gem 'dotenv-railsの追加
    - .envでAPIキーに環境変数を設定
    - .envを.gitignoreに追加
- ビューファイルにGoogleMapを読み込むための記述を追加

## 達成条件
- [x] 比較結果画面にGoogleMapが横並びで表示される

## 備考
### 実装メモ
[Notion](https://www.notion.so/9c7403683a214da087c9ad731b848b7d?pvs=4)
### 画面イメージ
[![Image from Gyazo](https://i.gyazo.com/22286e7043386e4fe533feea72119f5c.png)](https://gyazo.com/22286e7043386e4fe533feea72119f5c)
