### PR TITLE
gem pry-railsのインストールのやり直し

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,12 +53,14 @@ gem 'sorcery', '0.16.3'
 # 環境変数の管理
 gem'dotenv-rails'
 
-# デバックツール
-gem 'pry-rails'
-
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ]
+
+  # デバックツール
+  gem 'pry-rails'
+  gem 'pry-byebug'
+  gem 'pry-doc'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,6 +85,7 @@ GEM
     bootsnap (1.18.3)
       msgpack (~> 1.2)
     builder (3.3.0)
+    byebug (11.1.3)
     capybara (3.40.0)
       addressable
       matrix
@@ -193,6 +194,12 @@ GEM
     pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
+    pry-byebug (3.10.1)
+      byebug (~> 11.0)
+      pry (>= 0.13, < 0.15)
+    pry-doc (1.5.0)
+      pry (~> 0.11)
+      yard (~> 0.9.11)
     pry-rails (0.3.11)
       pry (>= 0.13.0)
     psych (5.1.2)
@@ -317,6 +324,7 @@ GEM
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
+    yard (0.9.36)
     zeitwerk (2.6.16)
 
 PLATFORMS
@@ -336,6 +344,8 @@ DEPENDENCIES
   jbuilder
   jsbundling-rails
   pg (~> 1.1)
+  pry-byebug
+  pry-doc
   pry-rails
   puma (>= 5.0)
   rails (~> 7.1.3, >= 7.1.3.4)


### PR DESCRIPTION
# 概要
gem pry-railsのインストールのやり直し

## 実装内容
- 開発とテスト環境で使用のため、記述場所を変更
- 'pry-byebug'と'pry-doc'を追加