### PR TITLE
Locationテーブルに地点データを格納

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,9 +1,53 @@
-# This file should ensure the existence of records required to run the application in every environment (production,
-# development, test). The code here should be idempotent so that it can be executed at any point in every environment.
-# The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
-#
-# Example:
-#
-#   ["Action", "Comedy", "Drama", "Horror"].each do |genre_name|
-#     MovieGenre.find_or_create_by!(name: genre_name)
-#   end
+locations = [
+  { name: "北海道札幌市", latitude: 43.06417, longitude: 141.34694 },
+  { name: "青森県青森市", latitude: 40.82444, longitude: 140.74 },
+  { name: "岩手県盛岡市", latitude: 39.70361, longitude: 141.1525 },
+  { name: "宮城県仙台市", latitude: 38.26889, longitude: 140.87194 },
+  { name: "秋田県秋田市", latitude: 39.71861, longitude: 140.1025 },
+  { name: "山形県山形市", latitude: 38.24056, longitude: 140.36333 },
+  { name: "福島県福島市", latitude: 37.75, longitude: 140.46778 },
+  { name: "茨城県水戸市", latitude: 36.34139, longitude: 140.44667 },
+  { name: "栃木県宇都宮市", latitude: 36.56583, longitude: 139.88361 },
+  { name: "群馬県前橋市", latitude: 36.39111, longitude: 139.06083 },
+  { name: "埼玉県さいたま市", latitude: 35.85694, longitude: 139.64889 },
+  { name: "千葉県千葉市", latitude: 35.60472, longitude: 140.12333 },
+  { name: "東京都新宿区", latitude: 35.68944, longitude: 139.69167 },
+  { name: "神奈川県横浜市", latitude: 35.44778, longitude: 139.6425 },
+  { name: "新潟県新潟市", latitude: 37.90222, longitude: 139.02361 },
+  { name: "富山県富山市", latitude: 36.69528, longitude: 137.21139 },
+  { name: "石川県金沢市", latitude: 36.59444, longitude: 136.62556 },
+  { name: "福井県福井市", latitude: 36.06528, longitude: 136.22194 },
+  { name: "山梨県甲府市", latitude: 35.66389, longitude: 138.56833 },
+  { name: "長野県長野市", latitude: 36.65139, longitude: 138.18111 },
+  { name: "岐阜県岐阜市", latitude: 35.42333, longitude: 136.76056 },
+  { name: "静岡県静岡市", latitude: 34.97556, longitude: 138.3825 },
+  { name: "愛知県名古屋市", latitude: 35.18028, longitude: 136.90667 },
+  { name: "三重県津市", latitude: 34.73028, longitude: 136.50861 },
+  { name: "滋賀県大津市", latitude: 35.00444, longitude: 135.86833 },
+  { name: "京都府京都市", latitude: 35.02139, longitude: 135.75556 },
+  { name: "大阪府大阪市", latitude: 34.68639, longitude: 135.52 },
+  { name: "兵庫県神戸市", latitude: 34.69139, longitude: 135.18306 },
+  { name: "奈良県奈良市", latitude: 34.68528, longitude: 135.83278 },
+  { name: "和歌山県和歌山市", latitude: 34.22611, longitude: 135.1675 },
+  { name: "鳥取県鳥取市", latitude: 35.50361, longitude: 134.23833 },
+  { name: "島根県松江市", latitude: 35.47222, longitude: 133.05056 },
+  { name: "岡山県岡山市", latitude: 34.66167, longitude: 133.935 },
+  { name: "広島県広島市", latitude: 34.39639, longitude: 132.45944 },
+  { name: "山口県山口市", latitude: 34.18583, longitude: 131.47139 },
+  { name: "徳島県徳島市", latitude: 34.06583, longitude: 134.55944 },
+  { name: "香川県高松市", latitude: 34.34028, longitude: 134.04333 },
+  { name: "愛媛県松山市", latitude: 33.83944, longitude: 132.76556 },
+  { name: "高知県高知市", latitude: 33.55972, longitude: 133.53111 },
+  { name: "福岡県福岡市", latitude: 33.60639, longitude: 130.41806 },
+  { name: "佐賀県佐賀市", latitude: 33.24944, longitude: 130.29889 },
+  { name: "長崎県長崎市", latitude: 32.74472, longitude: 129.87361 },
+  { name: "熊本県熊本市", latitude: 32.78972, longitude: 130.74167 },
+  { name: "大分県大分市", latitude: 33.23806, longitude: 131.6125 },
+  { name: "宮崎県宮崎市", latitude: 31.91111, longitude: 131.42389 },
+  { name: "鹿児島県鹿児島市", latitude: 31.56028, longitude: 130.55806 },
+  { name: "沖縄県那覇市", latitude: 26.2125, longitude: 127.68111 }
+]
+
+locations.each do |location|
+  Location.create(location)
+end


### PR DESCRIPTION
# 概要
Locationテーブルに地点データを格納

## 実装内容
- seeds.rbファイルを用いてLocationsテーブルに地点データを格納する

## 達成条件
- [x]  Locationsテーブルにデータが格納される

## 備考
### 実装メモ
[Notion](https://www.notion.so/Location-cc8d34016678459298c96d7701a8afa3?pvs=4)

### 画面イメージ
Location.allでデータの内容を確認
[![Image from Gyazo](https://i.gyazo.com/dffcc5577268920b25602a24de3cd15d.png)](https://gyazo.com/dffcc5577268920b25602a24de3cd15d)

Location.countでデータの数を確認
[![Image from Gyazo](https://i.gyazo.com/a961d631ad6ad42ef6e1b503fdc39149.png)](https://gyazo.com/a961d631ad6ad42ef6e1b503fdc39149)

closed #65