### PR TITLE
クイズの選択肢を追加

### DIFF
--- a/app/controllers/quizzes_controller.rb
+++ b/app/controllers/quizzes_controller.rb
@@ -3,12 +3,16 @@ class QuizzesController < ApplicationController
   def new
     # ランダムに並び替え、そのうち2件を取得する
     @locations = Location.order("RANDOM()").limit(2)
-    # calculate_distanceのメソッドに対して上記で取得した2地点を引数として渡す
-    @distance = calculate_distance(@locations[0], @locations[1])
-
     # Javascriptに渡せるように設定
     gon.location1 = @locations[0]
     gon.location2 = @locations[1]
+
+    # calculate_distanceのメソッドに対して上記で取得した2地点を引数として渡す
+    @distance = calculate_distance(@locations[0], @locations[1])
+
+    # generate_choicesメソッドにAPIで計算した正答な距離を引数として@choicesに代入
+    @choices = generate_choices(@distance)
+
   end
 
   def show;end
@@ -32,4 +36,31 @@ class QuizzesController < ApplicationController
     distance_in_km = data["rows"][0]["elements"][0]["distance"]["value"] / 1000.0
     distance_in_km.round(1)
   end
+
+
+  # 選択肢を生成するロジック
+  def generate_choices(distance)
+
+    # distanceに基づいてダミーデータの範囲を設定(±30%)
+    variation = (distance * 0.3).round
+
+    # distanceを基準としたダミーデータを4つ作成する。整数で出力。
+    dummy_distances = [
+      (distance + rand(variation..(variation * 2))).to_i,
+      (distance + rand(variation..(variation * 2))).to_i,
+      (distance - rand(variation..(variation * 2))).to_i,
+      (distance - rand(variation..(variation * 2))).to_i
+    ]
+
+    # 上記のdummy_distanceから0以上の値を条件に取り出す
+    valid_distances = dummy_distances.select { |d| d >= 0 }
+
+    # 4つのダミーデータから2つをランダムで選択し正答と合わせてchoiceに代入する
+    selected_dummies = valid_distances.sample(2)
+    choices = [distance.to_i] + selected_dummies
+
+    # 要素を並び替える
+    choices.shuffle
+  end
+
 end

--- a/app/views/quizzes/new.html.erb
+++ b/app/views/quizzes/new.html.erb
@@ -15,9 +15,13 @@
     <!-- 解答選択部分 背景みどり -->
     <div class="bg-primary rounded-lg text-secondary">
       <div class="flex flex-row p-5 m-5">
-        <button class="btn bg-base-100 m-3 "><%= @distance %>km</button>
-        <button class="btn bg-base-100 m-3"><%= @distance %>km</button>
-        <button class="btn bg-base-100 m-3"><%= @distance %>km</button>
+        <div id="choices">
+          <% @choices.each do |choice| %>
+            <button class="btn text-secondary font-bold bg-base-100 m-3">
+              <%= choice %>km
+            </button>
+          <% end %>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
# 概要
クイズの選択肢を追加

## 実装内容
- quizzesコントローラーに選択肢を生成するメソッドを追加
- ビューのボタンに回答の選択肢を表示する

## 達成条件
- [x] ビューに正答を含む3つの選択肢が表示される

## 備考
### 実装メモ
[Notion](https://www.notion.so/b6e22a5eac7e4a05b6678514244742d8?pvs=4)
### 画面イメージ
[![Image from Gyazo](https://i.gyazo.com/a65019f81eee908830544ff194eac9fe.png)](https://gyazo.com/a65019f81eee908830544ff194eac9fe)

closed #69