### PR TITLE
フラッシュメッセージの表示

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,9 +1,3 @@
 class ApplicationController < ActionController::Base
-  # before_action :require_login
-
-  # private
-
-  # def not_authenticated
-  #   redirect_to root_path
-  # end
+  add_flash_types :success, :danger
 end

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -7,14 +7,17 @@ class UserSessionsController < ApplicationController
     @user = login(params[:email], params[:password])
 
     if @user
+      flash[:success] = "ログインに成功しました"
       redirect_to root_path
     else
-      render :new
+      flash.now[:error] = "ログインに失敗しました"
+      render :new, status: :unprocessable_entity
     end
   end
 
   def destroy
     logout
+    flash[:success] = "ログアウトしました"
     redirect_to root_path, status: :see_other
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -11,9 +11,11 @@ class UsersController < ApplicationController
   def create
     @user = User.new(user_params)
     if @user.save
+      flash[:success] = "ユーザー登録に成功しました"
       redirect_to root_path
     else
-      render :new
+      flash.now[:error] = "ユーザー登録に失敗しました"
+      render :new, status: :unprocessable_entity
     end
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,10 @@
 module ApplicationHelper
+  def flash_background_color(type)
+    case type.to_sym
+    when :success then "bg-[#62CB93]"
+    when :alert  then "bg-[#CBB162]"
+    when :error  then "bg-[#B03B3B]"
+    else "bg-[#C6E4EC]"
+    end
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,6 +19,7 @@
       <% else %>
         <%= render 'shared/before_login_header' %>
       <% end %>
+      <%= render 'shared/flash_message' %>
       <%= yield %>
     </div>
   </body>

--- a/app/views/shared/_flash_message.html.erb
+++ b/app/views/shared/_flash_message.html.erb
@@ -1,0 +1,5 @@
+<% flash.each do |message_type, message| %>
+  <div class="<%= flash_background_color(message_type) %> px-4 py-2 rounded-md text-white mb-4">
+    <%= message %>
+  </div>
+<% end %>


### PR DESCRIPTION
# 概要
ログイン・ログアウト・ユーザー作成時のフラッシュメッセージの表示

## 実装内容
- フラッシュメッセージを表示するための各設定を追加

## 達成条件
- [x] ログイン、ログアウト時にフラッシュメッセージが表示される- [x] 
- [x] ユーザー登録時にフラッシュメッセージが表示される- [x] 

## 備考
### 実装メモ
[Notion](https://www.notion.so/8bcd4c6dd5e14abea789ddad78e460a9?pvs=

### 画面イメージ
[![Image from Gyazo](https://i.gyazo.com/19b9507ec1dd222ef1510f3009524cfc.png)](https://gyazo.com/19b9507ec1dd222ef1510f3009524cfc)
[![Image from Gyazo](https://i.gyazo.com/edd6d71aaafe7a2046f2048acbe21f2b.png)](https://gyazo.com/edd6d71aaafe7a2046f2048acbe21f2b)
[![Image from Gyazo](https://i.gyazo.com/38082a87d9f6ced0eed077fa131ab49d.png)](https://gyazo.com/38082a87d9f6ced0eed077fa131ab49d)
[![Image from Gyazo](https://i.gyazo.com/f11859ce3ab3efa10d90b146656a26d3.png)](https://gyazo.com/f11859ce3ab3efa10d90b146656a26d3)
[![Image from Gyazo](https://i.gyazo.com/9c31cdcf94f907f426ea6250d01520d0.png)](https://gyazo.com/9c31cdcf94f907f426ea6250d01520d0)

closed #52 