### PR TITLE
マイページのビューの追加

### DIFF
--- a/app/controllers/mypages_controller.rb
+++ b/app/controllers/mypages_controller.rb
@@ -1,0 +1,9 @@
+class MypagesController < ApplicationController
+
+  def edit; end
+
+  def update;end
+
+  def show; end
+
+end

--- a/app/views/mypages/edit.html.erb
+++ b/app/views/mypages/edit.html.erb
@@ -1,0 +1,19 @@
+<div class="flex flex-col min-h-screen bg-base-100">
+  <div class="p-10 bg-base-100 rounded-lg text-secondary">
+
+    <h2 class="text-2xl text-text-color mb-8"><%= t('.title')%></h2>
+      <%= form_with model: @user, url: mypage_path, method: :put do |f| %>
+        <div class="mb-3">
+          <%= f.label :name, class: "flexform-label" %>
+          <%= f.text_field :name, class: "form-control" %>
+        </div>
+        <div class="mb-10">
+          <%= f.label :email, class: "form-label" %>
+          <%= f.email_field :email, class: "form-control" %>
+        </div>
+        <%= f.submit t('helpers.submit.update'), class: "btn btn-primary" %>
+      <% end %>
+    </div>
+
+  </div>
+</div>

--- a/app/views/mypages/show.html.erb
+++ b/app/views/mypages/show.html.erb
@@ -1,0 +1,23 @@
+<div class="flex flex-col min-h-screen bg-base-100">
+  <div class="p-10 bg-base-100 rounded-lg text-secondary">
+    <h2 class="text-2xl text-text-color mb-8"><%= t('.title')%></h2>
+
+    <table class="table">
+      <tr>
+        <th scope="row"><%= User.human_attribute_name(:email) %> </th>
+        <td><%= current_user.email %></td>
+      </tr>
+      <tr>
+        <th scope="row"><%= User.human_attribute_name(:name) %></th>
+        <td><%= current_user.name %></td>
+      </tr>
+    </table>
+
+    <div class="flex justify-center py-10">
+      <button class="btn btn-primary text-secondary m-5">
+        <%= link_to "編集", edit_mypage_path %>
+      </button>
+    </div>
+
+  </div>
+</div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -8,6 +8,11 @@
     <ul class="menu menu-horizontal space-x-4">
       <li>
         <button class="btn btn-neutral bg-base-100 text-secondary">
+          <%= link_to t('shared.header.mypage'), mypage_path, class: "nav-link"%>
+        </button>
+      </li>
+      <li>
+        <button class="btn btn-neutral bg-base-100 text-secondary">
           <%= link_to t('shared.header.logout'), logout_path, class: "nav-link", data: { turbo_method: :delete }%>
         </button>
       </li>

--- a/config/application.rb
+++ b/config/application.rb
@@ -30,5 +30,9 @@ module Myapp
       g.helper false
       g.test_framework nil
     end
+
+    # i18n対応
+    config.i18n.default_locale = :ja
+
   end
 end

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -7,5 +7,9 @@ ja:
       update: 更新
     # フォームのラベル
     label:
+      name: 名前
       email: メールアドレス
       password: パスワード
+  attributes:
+    attributes: 名前
+    email: メールアドレス

--- a/config/locales/views/mypages/ja.yml
+++ b/config/locales/views/mypages/ja.yml
@@ -1,0 +1,6 @@
+ja:
+  mypages:
+    show:
+      title: マイページ
+    edit:
+      title: マイページ編集

--- a/config/locales/views/shared/ja.yml
+++ b/config/locales/views/shared/ja.yml
@@ -4,6 +4,7 @@ ja:
       login: ログイン
       create_user: 新規登録
     header:
+      mypage: マイページ
       logout: ログアウト
     footer:
       terms: 利用規約

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,8 +18,11 @@ Rails.application.routes.draw do
   post 'login', to: "user_sessions#create"
   delete 'logout', to: 'user_sessions#destroy'
 
-  ## クイズ、解答の表示
+  # クイズ、解答の表示
   resources :quizzes, only: %i[new]
   get 'answer', to: 'quizzes#show'
+
+  # プロフィール
+  resource :mypage, only: %i[show edit update]
 
 end


### PR DESCRIPTION
# 概要
マイページのビューの追加

## 実装内容
- mypagesコントローラーを設定
- ルーティングの設定
- マイページの詳細画面・編集画面を作成 

## 達成条件
- [x] マイページの詳細画面・編集画面が表示される
- [x]  ヘッダーのリンクからマイページへ遷移する


## 備考
### 実装メモ
[Notion](https://www.notion.so/b5df3a4200394f1aa32316c773941a05?pvs=4)

### 画面イメージ
[![Image from Gyazo](https://i.gyazo.com/8790a9d630458df785b4883252992cb4.png)](https://gyazo.com/8790a9d630458df785b4883252992cb4)

[![Image from Gyazo](https://i.gyazo.com/cb31bdc6e45872bd89c3998e6eacdee5.png)](https://gyazo.com/cb31bdc6e45872bd89c3998e6eacdee5)

[![Image from Gyazo](https://i.gyazo.com/f00f88bfdec2fa7911102a9ed278e0ad.gif)](https://gyazo.com/f00f88bfdec2fa7911102a9ed278e0ad)

closed #22