### PR TITLE
クイズ履歴の保存機能

### DIFF
--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -1,4 +1,7 @@
 class Location < ApplicationRecord
+  # locationをquiz_historiesのlocation1とlocation2として、複数関連付ける
+  has_many :quiz_histories_as_location1, class_name: 'QuizHistory', foreign_key: 'location1_id'
+  has_many :quiz_histories_as_location2, class_name: 'QuizHistory', foreign_key: 'location2_id'
 
   # 入力必須（名称、緯度、経度）
   validates :name, presence: true, length: { maximum: 255 }

--- a/app/models/quiz_history.rb
+++ b/app/models/quiz_history.rb
@@ -1,0 +1,12 @@
+class QuizHistory < ApplicationRecord
+  belongs_to :user
+  # ランダムで取得した2つのLocationを1と2に分けて関連付ける
+  belongs_to :location1, class_name: 'Location'
+  belongs_to :location2, class_name: 'Location'
+
+  validates :user_answer, presence: true, numericality: { greater_than_or_equal_to: 0 } # ユーザーが選択した距離が0以上の数値であること
+  validates :correct_answer, presence: true, numericality: { greater_than_or_equal_to: 0 } # 正答の距離が0以上の数値であること
+  validates :is_correct, inclusion: { in: [true, false] } # trueかfalse以外は不可
+  validates :answered_at, presence: true
+
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,9 @@
 class User < ApplicationRecord
   authenticates_with_sorcery!
 
+  # 一般的なクイズ履歴の関連付け
+  has_many :quiz_histories
+
   # 3文字以上（新規レコード作成もしくはcrypted_passwordカラムが更新される時のみ適応）
   validates :password, length: { minimum: 3 }, if: -> { new_record? || changes[:crypted_password] }
   # 値が空でない・passwordの値と一致する（新規レコード作成もしくはcrypted_passwordカラムが更新される時のみ適応）
@@ -10,4 +13,5 @@ class User < ApplicationRecord
   validates :name, presence: true, length: { maximum: 255 }
   # 値が空でない・ユニークな値
   validates :email, presence: true, uniqueness: true
+
 end

--- a/db/migrate/20240922094404_create_quiz_histories.rb
+++ b/db/migrate/20240922094404_create_quiz_histories.rb
@@ -1,0 +1,17 @@
+class CreateQuizHistories < ActiveRecord::Migration[7.1]
+  def change
+    create_table :quiz_histories do |t|
+      t.references :user, null: false, foreign_key: true # ユーザーが存在する ＝ログインしないと履歴が保存されない
+      t.references :location1, null: false, foreign_key: { to_table: :locations }
+      t.references :location2, null: false, foreign_key: { to_table: :locations }
+      t.float :user_answer, null: false
+      t.float :correct_answer, null: false
+      t.boolean :is_correct, null: false
+      t.datetime :answered_at, null: false, default: -> { 'CURRENT_TIMESTAMP' }
+
+      t.timestamps
+    end
+
+    add_index :quiz_histories, [:user_id, :answered_at] # ユーザーごとの回答履歴を表示しやすくする
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_08_29_084845) do
+ActiveRecord::Schema[7.1].define(version: 2024_09_22_094404) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -32,6 +32,22 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_29_084845) do
     t.index ["latitude", "longitude"], name: "index_locations_on_latitude_and_longitude", unique: true
   end
 
+  create_table "quiz_histories", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "location1_id", null: false
+    t.bigint "location2_id", null: false
+    t.float "user_answer", null: false
+    t.float "correct_answer", null: false
+    t.boolean "is_correct", null: false
+    t.datetime "answered_at", default: -> { "CURRENT_TIMESTAMP" }, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["location1_id"], name: "index_quiz_histories_on_location1_id"
+    t.index ["location2_id"], name: "index_quiz_histories_on_location2_id"
+    t.index ["user_id", "answered_at"], name: "index_quiz_histories_on_user_id_and_answered_at"
+    t.index ["user_id"], name: "index_quiz_histories_on_user_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "email", null: false
     t.string "crypted_password"
@@ -41,4 +57,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_29_084845) do
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 
+  add_foreign_key "quiz_histories", "locations", column: "location1_id"
+  add_foreign_key "quiz_histories", "locations", column: "location2_id"
+  add_foreign_key "quiz_histories", "users"
 end


### PR DESCRIPTION
# 概要
クイズ履歴の保存機能

## 実装内容
- Quiz_Historyモデルの追加と設定
- 各モデルとの関連付けとバリデーションを設定
- quizzesコントローラーにユーザーがログイン中にのみデータが保存されるような機能を追加

## 達成条件
- [x] Quiz_Historyテーブルにデータが保存される

## 備考
### 実装メモ
[Notion](https://www.notion.so/109c61db530f80a2a853d751e6b67e55?pvs=4)

closed #84