### PR TITLE
チャレンジモードの実装

### DIFF
--- a/app/controllers/challenge_mode/quizzes_controller.rb
+++ b/app/controllers/challenge_mode/quizzes_controller.rb
@@ -1,0 +1,136 @@
+module ChallengeMode
+  class QuizzesController < ApplicationController
+    # QuizUtilsモジュール（calculate_distanceメソッド、generate_choicesメソッド）
+    include QuizUtils
+
+    # ログイン必須
+    before_action :require_login
+
+    def new
+      # チャレンジモードのセッションを初期化（セッションが存在しなければ実行）
+      session[:challenge_mode] ||= {
+        question_count: 10,  # 出題数
+        current_question: 0,  # 現在の問題数
+        correct_answers: 0  # 正解数
+      }
+
+      # challenge_modeハッシュをchallenge変数に代入し、キーをシンボルに変換。変換しとかないと動かなかった
+      challenge = session[:challenge_mode].deep_symbolize_keys
+
+      # 全ての問題に解答済みの場合、結果画面にリダイレクト
+      if challenge[:current_question] >= challenge[:question_count]
+        redirect_to result_challenge_mode_quizzes_path
+        return
+      end
+
+      # ランダムに並び替え、そのうち2件を取得する
+      @locations = Location.order("RANDOM()").limit(2)
+
+      # Javascriptに渡せるように設定
+      gon.location1 = @locations[0]  # 地点1
+      gon.location2 = @locations[1]  # 地点2
+
+      # calculate_distanceのメソッドに対して上記で取得した2地点を引数として渡す
+      @distance = calculate_distance(@locations[0], @locations[1])
+
+      # generate_choicesメソッドにAPIで計算した正答な距離を引数として@choicesに代入
+      @choices = generate_choices(@distance)
+
+      # セッションに保存
+      session[:locations] = @locations.map(&:id)
+      session[:correct_answer] = @distance
+      session[:choices] = @choices
+
+      # 出題カウントを増やす
+      challenge[:current_question] += 1
+      session[:challenge_mode] = challenge
+    end
+
+
+    def show
+      # newで作成されたセッションの情報を読み込み、キーをシンボルに変換
+      challenge = session[:challenge_mode].deep_symbolize_keys
+
+      # 各sessionの値を取得し、インスタンス変数に代入する
+      @locations = Location.find(session[:locations])
+      @correct_answer = session[:correct_answer].to_i
+      @selected_choice = params[:selected_choice].to_i
+
+      # # JavaScriptに渡せるように設定
+      # ## 地点1
+      # gon.latitude1 = @locations[0].latitude
+      # gon.longitude1 = @locations[0].longitude
+      # ## 地点2
+      # gon.latitude2 = @locations[1].latitude
+      # gon.longitude2 = @locations[1].longitude
+
+      # 正誤判定
+      is_correct = @selected_choice == @correct_answer
+
+      # ユーザーが選んだ回答が正解か判断し、その結果をインスタンス変数に代入する
+      if is_correct
+        @result = t('quizzes.show.correct')
+      else
+        @result = t('quizzes.show.incorrect')
+      end
+
+      # 正解の場合、正解数をカウントアップ
+      if is_correct
+        challenge[:correct_answers] += 1
+      end
+
+      # 回答履歴を保存
+      QuizHistory.create!(
+        user_id: @current_user.id,
+        location1_id: @locations[0].id,
+        location2_id: @locations[1].id,
+        user_answer: @selected_choice,
+        correct_answer: @correct_answer,
+        is_correct: is_correct,
+        answered_at: Time.current
+      )
+
+      # セッションの更新
+      session[:challenge_mode] = challenge
+
+      # 次のクイズに進むか、結果画面に遷移
+      if challenge[:current_question] < challenge[:question_count]
+        redirect_to new_challenge_mode_quiz_path
+      else
+        redirect_to result_challenge_mode_quizzes_path
+      end
+    end
+
+
+    def result
+      # セッションがない場合はトップページにリダイレクト
+      unless session[:challenge_mode]
+        redirect_to root_path, alert: "セッションが期限切れです。もう一度チャレンジしてください。"
+        return
+      end
+
+      # newで作成されたセッションの情報を読み込み、キーをシンボルに変換
+      challenge = session[:challenge_mode].deep_symbolize_keys
+
+      # セッションの情報をインスタンス変数に代入
+      @correct_answers = challenge[:correct_answers]
+      @question_count = challenge[:question_count]
+
+      # 結果をデータベースに保存
+      ChallengeResult.create!(
+        user: current_user,
+        total_questions: @question_count,
+        correct_answers: @correct_answers
+      )
+
+      # セッションのクリア
+      session.delete(:challenge_mode)
+    end
+
+
+    # private
+    #Quiz_Utilsにcalculate_distanceメソッドのモジュール
+    #Quiz_Utilsにgenerate_choicesメソッドのモジュール
+
+  end
+end

--- a/app/controllers/concerns/quiz_utils.rb
+++ b/app/controllers/concerns/quiz_utils.rb
@@ -1,6 +1,5 @@
-class QuizzesController < ApplicationController
-  # ログインしている場合にのみユーザーをセットする
-  before_action :set_user_if_logged_in
+module QuizUtils
+  extend ActiveSupport::Concern # privateのメソッドをinclude先でもprivateにするために必要
 
   def new
     # ランダムに並び替え、そのうち2件を取得する
@@ -22,55 +21,12 @@ class QuizzesController < ApplicationController
     session[:choices] = @choices
   end
 
-  def show
-    # 各sessionの値を取得し、インスタンス変数に代入する
-    @locations = Location.find(session[:locations])
-    @correct_answer = session[:correct_answer].to_i
-    @selected_choice = params[:selected_choice].to_i
-
-    # JavaScriptに渡せるように設定
-    ## 地点1
-    gon.latitude1 = @locations[0].latitude
-    gon.longitude1 = @locations[0].longitude
-
-    ## 地点2
-    gon.latitude2 = @locations[1].latitude
-    gon.longitude2 = @locations[1].longitude
-
-    # ログインしている場合にのみ回答履歴を保存
-    if @current_user
-      QuizHistory.create!(
-        user_id: @current_user.id,
-        location1_id: @locations[0].id,
-        location2_id: @locations[1].id,
-        user_answer: @selected_choice,
-        correct_answer: @correct_answer,
-        is_correct: @selected_choice == @correct_answer,
-        answered_at: Time.current
-      )
-    end
-
-    # ユーザーが選んだ回答が正解か判断し、その結果をインスタンス変数に代入する
-    if @selected_choice == @correct_answer
-      @result = t('quizzes.show.correct')
-    else
-      @result = t('quizzes.show.incorrect')
-    end
-  end
-
   private
 
-  # ログイン中のユーザーをセット
-  def set_user_if_logged_in
-    @current_user = current_user if logged_in?
-  end
-
-  # 距離計算ロジック location1とlocation2は、newメソッドの@locations[0]と@locations[1]とイコール
+  # 距離計算ロジック
   def calculate_distance(location1, location2)
-    # 出発地点と到着地点の緯度経度をそれぞれoriginとdestinationに代入
     origin = "#{location1.latitude},#{location1.longitude}"
     destination = "#{location2.latitude},#{location2.longitude}"
-
     api_key = ENV['MAPS_JAVASCRIPT_API']
 
     # APIエンドポイントに対して2点間の距離を計算するための情報を渡す
@@ -86,7 +42,6 @@ class QuizzesController < ApplicationController
 
   # 選択肢を生成するロジック
   def generate_choices(distance)
-
     # distanceに基づいてダミーデータの範囲を設定(±30%)
     variation = (distance * 0.3).round
 
@@ -109,4 +64,9 @@ class QuizzesController < ApplicationController
     choices.shuffle
   end
 
+
+  # ログイン中のユーザーをセット
+  def set_user_if_logged_in
+    @current_user = current_user if logged_in?
+  end
 end

--- a/app/controllers/simple_mode/quizzes_controller.rb
+++ b/app/controllers/simple_mode/quizzes_controller.rb
@@ -1,0 +1,55 @@
+module SimpleMode
+  class QuizzesController < ApplicationController
+
+    # QuizUtilsモジュール（calculate_distanceメソッド、generate_choicesメソッド）
+    include QuizUtils
+
+    # ログインしている場合にのみユーザーをセットする
+    before_action :set_user_if_logged_in
+
+
+    # def new ;end #Quiz_Utilsにnewメソッドのモジュール
+
+
+    def show
+      # 各sessionの値を取得し、インスタンス変数に代入する
+      @locations = Location.find(session[:locations])
+      @correct_answer = session[:correct_answer].to_i
+      @selected_choice = params[:selected_choice].to_i
+
+      # JavaScriptに渡せるように設定
+      ## 地点1
+      gon.latitude1 = @locations[0].latitude
+      gon.longitude1 = @locations[0].longitude
+      ## 地点2
+      gon.latitude2 = @locations[1].latitude
+      gon.longitude2 = @locations[1].longitude
+
+      # ユーザーが選んだ回答が正解か判断し、その結果をインスタンス変数に代入する
+      if @selected_choice == @correct_answer
+        @result = t('quizzes.show.correct')
+      else
+        @result = t('quizzes.show.incorrect')
+      end
+
+      # ログインしている場合にのみ回答履歴を保存
+      if @current_user
+        QuizHistory.create!(
+          user_id: @current_user.id,
+          location1_id: @locations[0].id,
+          location2_id: @locations[1].id,
+          user_answer: @selected_choice,
+          correct_answer: @correct_answer,
+          is_correct: @selected_choice == @correct_answer,
+          answered_at: Time.current
+        )
+      end
+    end
+
+
+    # private
+    #Quiz_Utilsにcalculate_distanceメソッドのモジュール
+    #Quiz_Utilsにgenerate_choicesメソッドのモジュール
+
+  end
+end

--- a/app/models/challenge_result.rb
+++ b/app/models/challenge_result.rb
@@ -1,0 +1,6 @@
+class ChallengeResult < ApplicationRecord
+  belongs_to :user
+
+  validates :total_questions, presence: true, numericality: { greater_than: 0 }
+  validates :correct_answers, presence: true, numericality: { greater_than_or_equal_to: 0 }
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,8 +1,10 @@
 class User < ApplicationRecord
   authenticates_with_sorcery!
 
-  # 一般的なクイズ履歴の関連付け
-  has_many :quiz_histories
+  # Userモデルとquiz_historieモデルは一対多。ユーザーが削除されたら結果も削除
+  has_many :quiz_histories, dependent: :destroy
+  # Userモデルとchallenge_resultモデルは一対多。ユーザーが削除されたら結果も削除
+  has_many :challenge_results, dependent: :destroy
 
   # 3文字以上（新規レコード作成もしくはcrypted_passwordカラムが更新される時のみ適応）
   validates :password, length: { minimum: 3 }, if: -> { new_record? || changes[:crypted_password] }

--- a/app/views/challenge_mode/quizzes/new.html.erb
+++ b/app/views/challenge_mode/quizzes/new.html.erb
@@ -2,7 +2,8 @@
   <div class="p-10 bg-base-100">
     <!-- 問題文 背景みどり -->
     <div class="bg-primary rounded-lg text-secondary">
-      <div class="flex flex-row p-10">
+      <div class="flex flex-col p-10">
+        <h1><%= session[:challenge_mode][:current_question] %> / <%= session[:challenge_mode][:question_count] %>問目</h1>
         <p class="text-base"><span class="text-lg font-bold"><%= @locations[0].name %></span>から<span class="text-lg font-bold"><%= @locations[1].name %></span>までの距離は何kmあるでしょう？</p>
       </div>
     </div>
@@ -12,7 +13,7 @@
     <div class="bg-primary rounded-lg">
       <div class="flex flex-row justify-center p-5 m-8">
         <div id="choices">
-          <%= form_with url: answer_path, method: :get, local: true do %>
+          <%= form_with url: answer_challenge_mode_quizzes_path, method: :get, local: true do %>
             <% @choices.each do |choice| %>
               <button type="submit" name="selected_choice" value="<%= choice %>" class="btn text-secondary font-bold bg-base-100 m-3">
                 約<%= choice %>km

--- a/app/views/challenge_mode/quizzes/result.html.erb
+++ b/app/views/challenge_mode/quizzes/result.html.erb
@@ -1,0 +1,15 @@
+<div class="flex flex-col min-h-screen bg-base-100">
+  <div class="p-10 bg-base-100">
+    <!-- 問題文 背景みどり -->
+    <div class="bg-primary rounded-lg text-secondary">
+      <div class="flex flex-col p-10">
+        <h1 class="text-3xl font-bold mb-4">結果発表</h1>
+        <p>正解数: <%= @correct_answers %> / <%= @question_count %></p>
+        <%= link_to '解答の詳細を見る', "#", class: 'btn text-secondary font-bold bg-base-100 m-3' %>
+        <%= link_to 'もう一度挑戦する', start_challenge_mode_quizzes_path, class: 'btn text-secondary font-bold bg-base-100 m-3' %>
+        <%= link_to 'トップページへ戻る', root_path, class: 'btn text-secondary font-bold bg-base-100 m-3' %>
+      </div>
+    </div>
+    <br>
+  </div>
+</div>

--- a/app/views/challenge_mode/quizzes/show.html.erb
+++ b/app/views/challenge_mode/quizzes/show.html.erb
@@ -1,7 +1,9 @@
-<div class="flex flex-col h-screen bg-base-100 p-10">
+<%
+=begin%>
+ <div class="flex flex-col h-screen bg-base-100 p-10">
   <div class="bg-primary rounded-lg text-secondary flex-1 flex flex-col">
     <div class="flex flex-col p-10 flex-1">
-
+      <h1><%= session[:challenge_mode][:current_question] %> / <%= session[:challenge_mode][:question_count] %>問目</h1>
       <h2 class="text-5xl font-semibold text-center mb-5"><%= @result %></h2>
 
       <div class="bg-primary rounded-lg text-secondary mb-5">
@@ -31,9 +33,13 @@
   <br>
   <div class="flex justify-end">
     <div class="menu menu-horizontal space-x-4">
-      <button class="btn btn-primary text-secondary">
-        <%= link_to "他にも比べてみる！", new_quiz_path %>
-      </button>
+      <% if session[:challenge_mode][:current_question] < session[:challenge_mode][:question_count] %>
+        <%= link_to "次の質問へ", new_challenge_mode_quiz_path, class: 'btn btn-primary text-secondary' %>
+      <% else %>
+        <%= link_to "結果を見る", result_challenge_mode_quizzes_path, class: 'btn btn-primary text-secondary' %>
+      <% end %>
     </div>
   </div>
-</div>
+</div> 
+<%
+=end%>

--- a/app/views/challenge_mode/quizzes/start.html.erb
+++ b/app/views/challenge_mode/quizzes/start.html.erb
@@ -1,0 +1,19 @@
+<div class="flex flex-col min-h-screen bg-base-100">
+  <div class="p-10 bg-base-100">
+    <!-- 問題文 背景みどり -->
+    <div class="bg-primary rounded-lg text-secondary">
+      <div class="flex flex-col p-10">
+          <h1 class="text-3xl font-bold mb-4">チャレンジモードを開始しますか？</h1>
+          <p>チャレンジモードでは10問のクイズに挑戦し、全問の正答数を記録します。</p>
+          <p>準備ができたら、以下のボタンをクリックしてクイズを開始してください。</p>
+
+        <div class="flex flex-row justify-center p-5 m-8">
+        <button class="btn text-secondary font-bold bg-base-100 m-3">
+          <%= link_to 'クイズを開始する', new_challenge_mode_quiz_path, class: "nav-link"%>
+        </button>
+        </div>
+      </div>
+    </div>
+    <br>
+  </div>
+</div>

--- a/app/views/simple_mode/quizzes/new.html.erb
+++ b/app/views/simple_mode/quizzes/new.html.erb
@@ -1,0 +1,26 @@
+<div class="flex flex-col min-h-screen bg-base-100">
+  <div class="p-10 bg-base-100">
+    <!-- 問題文 背景みどり -->
+    <div class="bg-primary rounded-lg text-secondary">
+      <div class="flex flex-row p-10">
+        <p class="text-base"><span class="text-lg font-bold"><%= @locations[0].name %></span>から<span class="text-lg font-bold"><%= @locations[1].name %></span>までの距離は何kmあるでしょう？</p>
+      </div>
+    </div>
+    <br>
+
+    <!-- 解答選択部分 背景みどり -->
+    <div class="bg-primary rounded-lg">
+      <div class="flex flex-row justify-center p-5 m-8">
+        <div id="choices">
+          <%= form_with url: answer_simple_mode_quizzes_path, method: :get, local: true do %>
+            <% @choices.each do |choice| %>
+              <button type="submit" name="selected_choice" value="<%= choice %>" class="btn text-secondary font-bold bg-base-100 m-3">
+                約<%= choice %>km
+              </button>
+            <% end %>
+          <% end %>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/simple_mode/quizzes/show.html.erb
+++ b/app/views/simple_mode/quizzes/show.html.erb
@@ -1,0 +1,39 @@
+<div class="flex flex-col h-screen bg-base-100 p-10">
+  <div class="bg-primary rounded-lg text-secondary flex-1 flex flex-col">
+    <div class="flex flex-col p-10 flex-1">
+
+      <h2 class="text-5xl font-semibold text-center mb-5"><%= @result %></h2>
+
+      <div class="bg-primary rounded-lg text-secondary mb-5">
+        <div class="flex flex-row p-10">
+          <p class="text-base"><span class="text-lg font-bold"><%= @locations[0].name %></span>から<span class="text-lg font-bold"><%= @locations[1].name %></span>までの距離は<span class="text-lg font-bold">約<%= @correct_answer %> km</span>です。</p>
+        </div>
+      </div>
+
+      <!-- Google Maps API を読み込む -->
+      <script src="https://maps.googleapis.com/maps/api/js?key=<%= "#{ENV['MAPS_JAVASCRIPT_API']}" %>&language=ja&callback=initMap" async defer></script>
+
+      <div class="flex justify-center flex-1">
+        <div class="flex flex-row bg-primary rounded-lg text-secondary w-full">
+          <div class="flex flex-col m-3 p-3 bg-white w-full h-full">
+            <p class="text-base font-bold mb-2">ルート</p>
+            <div id="map" class="flex-1 w-full" style="height: 100%; width: 100%;"></div>
+          </div>
+        </div>
+      </div>
+
+      <!-- 外部ファイルからJavaScriptを読み込み -->
+      <%= javascript_include_tag 'map.js' %>
+
+    </div>
+  </div>
+
+  <br>
+  <div class="flex justify-end">
+    <div class="menu menu-horizontal space-x-4">
+      <button class="btn btn-primary text-secondary">
+        <%= link_to "他にも比べてみる！", new_simple_mode_quiz_path %>
+      </button>
+    </div>
+  </div>
+</div>

--- a/app/views/tops/index.html.erb
+++ b/app/views/tops/index.html.erb
@@ -15,7 +15,11 @@
     </p>
   </section>
 
-    <button class="btn btn-primary text-secondary mx-auto">
-      <%= link_to "クイズに挑戦！", new_quiz_path %>
+    <button class="btn btn-primary text-secondary m-10 mx-auto p-10">
+      <%= link_to "シンプルモードに挑戦！", new_simple_mode_quiz_path %>
+    </button>
+
+    <button class="btn btn-primary text-secondary m-10 mx-auto p-10">
+      <%= link_to "チャレンジモードに挑戦！", start_challenge_mode_quizzes_path %>
     </button>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,8 +19,24 @@ Rails.application.routes.draw do
   delete 'logout', to: 'user_sessions#destroy'
 
   # クイズ、解答の表示
-  resources :quizzes, only: %i[new]
-  get 'answer', to: 'quizzes#show'
+  namespace :simple_mode do
+    resources :quizzes, only: %i[new] do
+      collection do
+        get 'answer', to: 'quizzes#show'
+      end
+    end
+  end
+
+  # チャレンジモードのクイズと解答の表示
+  namespace :challenge_mode do
+    resources :quizzes, only: [:new, :start] do
+      collection do
+        get 'answer', to: 'quizzes#show'
+        get 'start', to: 'quizzes#start'
+        get 'result', to: 'quizzes#result'
+      end
+    end
+  end
 
   # プロフィール
   resource :mypage, only: %i[show edit update]

--- a/db/migrate/20240923070144_create_challenge_results.rb
+++ b/db/migrate/20240923070144_create_challenge_results.rb
@@ -1,0 +1,11 @@
+class CreateChallengeResults < ActiveRecord::Migration[7.1]
+  def change
+    create_table :challenge_results do |t|
+      t.references :user, null: false, foreign_key: true # ログイン必須
+      t.integer :total_questions, null: false, default: 10
+      t.integer :correct_answers, null: false, default: 0
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_09_22_094404) do
+ActiveRecord::Schema[7.1].define(version: 2024_09_23_070144) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -21,6 +21,15 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_22_094404) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["provider", "uid"], name: "index_authentications_on_provider_and_uid"
+  end
+
+  create_table "challenge_results", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.integer "total_questions", default: 10, null: false
+    t.integer "correct_answers", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_challenge_results_on_user_id"
   end
 
   create_table "locations", force: :cascade do |t|
@@ -57,6 +66,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_22_094404) do
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 
+  add_foreign_key "challenge_results", "users"
   add_foreign_key "quiz_histories", "locations", column: "location1_id"
   add_foreign_key "quiz_histories", "locations", column: "location2_id"
   add_foreign_key "quiz_histories", "users"


### PR DESCRIPTION
# 概要
チャレンジモードの実装

## 実装内容
- ChallengeResultモデルの作成と設定
- 各モデルの関連付けを追加
- ルーティングを追加
- コントローラーをsimple_modeとchallenge_modeに分割し、それぞれにquizzesコントローラーを作成
- 共通の処理をモジュールに分割
- ビューを作成

## 達成条件
- [x] 問題が10問連続で表示され、最後に正答数の結果が出力される


## 備考
- レイアウトは別途調整する

### 実装メモ
[Notion](https://www.notion.so/10-10ac61db530f80cc815fd8a2c3dbfb0b?pvs=4)

closed #114