### PR TITLE
ランキング表示機能の追加

### DIFF
--- a/app/views/challenge_mode/quizzes/ranking.html.erb
+++ b/app/views/challenge_mode/quizzes/ranking.html.erb
@@ -1,0 +1,31 @@
+<div class="flex flex-col min-h-screen bg-base-100">
+  <div class="p-10 bg-base-100">
+    <!-- 問題文 背景みどり -->
+    <div class="bg-primary rounded-lg text-secondary">
+      <div class="flex flex-col p-10">
+        <h1 class="text-3xl font-bold mb-10">チャレンジモード ランキング</h1>
+
+        <table class="table-auto w-full border-collapse border border-gray-200">
+          <thead>
+            <tr class="bg-white text-lg">
+              <th class="border border-gray-300 py-5">順位</th>
+              <th class="border border-gray-300 py-5">ユーザー名</th>
+              <th class="border border-gray-300 py-5">正答数</th>
+            </tr>
+          </thead>
+          <tbody>
+            <% @rankings.each_with_index do |result, index| %>
+              <tr class="bg-base-100">
+                <td class="border border-gray-300 px-4 py-2 text-center"><%= index + 1 %></td>
+                <td class="border border-gray-300 px-4 py-2"><%= result.user.name %></td>
+                <td class="border border-gray-300 px-4 py-2 text-center"><%= result.correct_answers %> / <%= result.total_questions %></td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+
+      </div>
+    </div>
+    <br>
+  </div>
+</div>

--- a/app/views/challenge_mode/quizzes/result.html.erb
+++ b/app/views/challenge_mode/quizzes/result.html.erb
@@ -6,10 +6,44 @@
         <h1 class="text-3xl font-bold mb-4">結果発表</h1>
         <p>正解数: <%= @correct_answers %> / <%= @question_count %></p>
         <%= link_to '解答の詳細を見る', "#", class: 'btn text-secondary font-bold bg-base-100 m-3' %>
+        <%= link_to 'ランキングを確認する', challenge_mode_ranking_path, class: 'btn text-secondary font-bold bg-base-100 m-3' %>
         <%= link_to 'もう一度挑戦する', start_challenge_mode_quizzes_path, class: 'btn text-secondary font-bold bg-base-100 m-3' %>
         <%= link_to 'トップページへ戻る', root_path, class: 'btn text-secondary font-bold bg-base-100 m-3' %>
       </div>
     </div>
     <br>
+
+
+    <!-- ランキングを表示 -->
+    <div class="mt-10 bg-primary rounded-lg text-secondary">
+      <div class="flex flex-col p-10">
+        <h1 class="text-3xl font-bold mb-10">チャレンジモード ランキング（上位20位）</h1>
+
+        <% if @rank_in_top_20 %>
+          <p class="text-xl font-bold mt-5 text-center text-red-500 mb-10">20位以内にランクインしました🎉</p>
+        <% end %>
+
+        <table class="table-auto w-full border-collapse border border-gray-200">
+          <thead>
+            <tr class="bg-white text-lg">
+              <th class="border border-gray-300 py-5">順位</th>
+              <th class="border border-gray-300 py-5">ユーザー名</th>
+              <th class="border border-gray-300 py-5">正答数</th>
+            </tr>
+          </thead>
+          <tbody>
+            <% @rankings.each_with_index do |result, index| %>
+              <tr class="<%= result.id == @current_challenge.id ? 'bg-yellow-100' : 'bg-base-100' %>">
+                <td class="border border-gray-300 px-4 py-2 text-center"><%= index + 1 %></td>
+                <td class="border border-gray-300 px-4 py-2"><%= result.user.name %></td>
+                <td class="border border-gray-300 px-4 py-2 text-center"><%= result.correct_answers %> / <%= result.total_questions %></td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+
+      </div>
+    </div>
+
   </div>
 </div>

--- a/app/views/tops/index.html.erb
+++ b/app/views/tops/index.html.erb
@@ -22,4 +22,8 @@
     <button class="btn btn-primary text-secondary m-10 mx-auto p-10">
       <%= link_to "チャレンジモードに挑戦！", start_challenge_mode_quizzes_path %>
     </button>
+
+    <button class="btn btn-primary text-secondary m-10 mx-auto p-10">
+      <%= link_to "チャレンジモードのランキングを見る", challenge_mode_ranking_path %>
+    </button>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,13 +29,14 @@ Rails.application.routes.draw do
 
   # チャレンジモードのクイズと解答の表示
   namespace :challenge_mode do
-    resources :quizzes, only: [:new, :start] do
+    resources :quizzes, only: [:new] do
       collection do
         get 'answer', to: 'quizzes#show'
         get 'start', to: 'quizzes#start'
         get 'result', to: 'quizzes#result'
       end
     end
+    get 'ranking', to: 'quizzes#ranking'
   end
 
   # プロフィール


### PR DESCRIPTION
# 概要
ランキング表示機能の追加

## 実装内容
- ルーティングの設定
- quizzesコントローラーにrankingアクションを追加
- quizzesコントローラーのresultアクションに結果画面にランキングを表示するための機能を追加
- ビューの作成

## 達成条件
- [x] 結果画面にランキングの上位20名が表示される
- [x] その挑戦結果が20位以内にランクインした場合、コメントと対象レコードの背景色を変更して表示
- [x] ランキング表示画面に全てのランキングが表示される

## 備考
### 実装メモ
[Notion](https://www.notion.so/10cc61db530f806c9a95fa2f3583d415?pvs=4)

closed #86