### PR TITLE
ログアウト時にチャレンジモードに遷移できないように設定

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,10 @@
 class ApplicationController < ActionController::Base
-  add_flash_types :success, :danger
+  add_flash_types :success, :danger, :alert
+
+  private
+
+  def not_authenticated
+    redirect_to login_path, alert: t('alerts.require_login')
+  end
+
 end

--- a/app/controllers/mypages_controller.rb
+++ b/app/controllers/mypages_controller.rb
@@ -1,8 +1,10 @@
 class MypagesController < ApplicationController
 
-  before_action :set_user, only: %i[edit update]
+  # user情報をセット
+  before_action :set_user
 
   def show; end
+
   def edit; end
 
   # 更新

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -14,4 +14,5 @@ ja:
     attributes: 名前
     email: メールアドレス
   alerts:
-    session_expired: "セッションが期限切れです。もう一度チャレンジしてください。"
+    session_expired: セッションが期限切れです。もう一度チャレンジしてください。
+    require_login: ログインが必要です


### PR DESCRIPTION
# 概要
ログアウト時にチャレンジモードに遷移できないように設定

## 実装内容
- フラッシュメッセージとログインページへの遷移を設定

## 達成条件
- [x] ログアウト状態でチャレンジモードのページに遷移しようとすると、ログインページに遷移しフラッシュメッセージが表示される

## 備考
### 実装メモ
[Notion](https://www.notion.so/114c61db530f80f4a127f30ccd3ea53d?pvs=4)

closed #123 