### PR TITLE
追加機能のテストを追加

### DIFF
--- a/spec/system/challenge_mode/challenge_mode_spec.rb
+++ b/spec/system/challenge_mode/challenge_mode_spec.rb
@@ -38,7 +38,9 @@ RSpec.describe 'チャレンジモードクイズ', type: :system do
     it '全10問の回答後に結果ページに遷移できること' do
       visit new_challenge_mode_quiz_path
       10.times do
-        find('button', text: '約500km', wait: 5).click
+        sleep 1
+        find('button', text: '約500km').click
+        sleep 1
       end
       expect(page).to have_current_path(result_challenge_mode_quizzes_path, ignore_query: true)
     end
@@ -52,12 +54,14 @@ RSpec.describe 'チャレンジモードクイズ', type: :system do
 
     it '正解した場合、履歴が保存されること' do
       click_on '約500km'
+      sleep 1
       expect(QuizHistory.count).to eq(1)
       expect(QuizHistory.last.is_correct).to be true
     end
 
     it '不正解の場合、履歴が保存されること' do
       click_on '約400km'
+      sleep 1
       expect(QuizHistory.count).to eq(1)
       expect(QuizHistory.last.is_correct).to be false
     end
@@ -71,14 +75,16 @@ RSpec.describe 'チャレンジモードクイズ', type: :system do
 
     it '結果発表の画面が正しく表示されること' do
       10.times do
-        find('button', text: '約500km', wait: 5).click
+        sleep 1
+        find('button', text: '約500km').click
+        sleep 1
       end
       expect(page).to have_current_path(result_challenge_mode_quizzes_path, ignore_query: true)
     end
 
     it '20位以内にランクインした場合、特別なメッセージが表示されること' do
       10.times do
-        find('button', text: '約500km', wait: 5).click
+        find('button', text: '約500km').click
       end
       expect(page).to have_current_path(result_challenge_mode_quizzes_path, ignore_query: true)
       expect(page).to have_content('20位以内にランクインしました🎉')
@@ -89,13 +95,14 @@ RSpec.describe 'チャレンジモードクイズ', type: :system do
     it 'ログインしていないユーザーがチャレンジモードにアクセスできないこと' do
       visit logout_path
       visit start_challenge_mode_quizzes_path
-      expect(page).to have_current_path(root_path)
+      expect(page).to have_current_path(login_path)
+      expect(page).to have_content('ログインが必要です')
     end
 
     it 'ログイン済みユーザーはチャレンジモードにアクセスできること' do
       login_as(user)
       visit start_challenge_mode_quizzes_path
-      expect(current_path).to eq(start_challenge_mode_quizzes_path)
+      expect(page).to have_current_path(start_challenge_mode_quizzes_path)
     end
   end
 end


### PR DESCRIPTION
# 概要
追加機能のテストを追加

## 実装内容
- チャレンジモードのシステムテストにログアウト時の画面の遷移と表示を追加
- 不安定な部分のテストの修正

## 達成条件
- [x] システムテストが通過する

## 備考
### 実装メモ
[Notion](https://www.notion.so/114c61db530f80ecafc1c0a27f4e1449?pvs=4)

closed #