### PR TITLE
クイズ履歴の表示

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,6 +65,9 @@ gem 'rails-i18n', '~> 7.0.0'
 # OGP設定に必要
 gem 'meta-tags'
 
+# ページネーション
+gem 'kaminari'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem 'debug', platforms: %i[mri windows]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -146,6 +146,18 @@ GEM
     json (2.7.2)
     jwt (2.8.2)
       base64
+    kaminari (1.2.2)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.2)
+      kaminari-activerecord (= 1.2.2)
+      kaminari-core (= 1.2.2)
+    kaminari-actionview (1.2.2)
+      actionview
+      kaminari-core (= 1.2.2)
+    kaminari-activerecord (1.2.2)
+      activerecord
+      kaminari-core (= 1.2.2)
+    kaminari-core (1.2.2)
     language_server-protocol (3.17.0.3)
     logger (1.6.0)
     loofah (2.22.0)
@@ -391,6 +403,7 @@ DEPENDENCIES
   gon
   jbuilder
   jsbundling-rails
+  kaminari
   meta-tags
   pg (~> 1.1)
   pry-byebug

--- a/app/controllers/mypages_controller.rb
+++ b/app/controllers/mypages_controller.rb
@@ -1,13 +1,14 @@
 class MypagesController < ApplicationController
-
-  # user情報をセット
   before_action :set_user
 
-  def show; end
+  def show
+    @quiz_histories = current_user.quiz_histories.includes(:location1, :location2)
+                                  .order(answered_at: :desc)
+                                  .page(params[:page])
+  end
 
   def edit; end
 
-  # 更新
   def update
     if @user.update(user_params)
       flash[:success] = t('mypages.edit.success', item: User.model_name.human)
@@ -18,15 +19,12 @@ class MypagesController < ApplicationController
     end
   end
 
-
   private
 
-  # ログイン中のユーザーのidを取得し、@userに代入
   def set_user
     @user = User.find(current_user.id)
   end
 
-  # userから各データを受け取ったパラメータ
   def user_params
     params.require(:user).permit(:email, :name)
   end

--- a/app/views/challenge_mode/quizzes/ranking.html.erb
+++ b/app/views/challenge_mode/quizzes/ranking.html.erb
@@ -1,8 +1,8 @@
 <div class="flex flex-col min-h-screen bg-base-100">
   <div class="p-10 bg-base-100">
-    <!-- 問題文 背景みどり -->
     <div class="bg-primary rounded-lg text-secondary">
       <div class="flex flex-col p-10">
+
         <h1 class="text-3xl font-bold mb-10">チャレンジモード ランキング</h1>
 
         <table class="table-auto w-full border-collapse border border-gray-200">

--- a/app/views/kaminari/_first_page.html.erb
+++ b/app/views/kaminari/_first_page.html.erb
@@ -1,0 +1,11 @@
+<%# Link to the "First" page
+  - available local variables
+    url:           url to the first page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="first">
+  <%= link_to_unless current_page.first?, t('views.pagination.first').html_safe, url, remote: remote %>
+</span>

--- a/app/views/kaminari/_gap.html.erb
+++ b/app/views/kaminari/_gap.html.erb
@@ -1,0 +1,8 @@
+<%# Non-link tag that stands for skipped pages...
+  - available local variables
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="page gap"><%= t('views.pagination.truncate').html_safe %></span>

--- a/app/views/kaminari/_last_page.html.erb
+++ b/app/views/kaminari/_last_page.html.erb
@@ -1,0 +1,11 @@
+<%# Link to the "Last" page
+  - available local variables
+    url:           url to the last page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="last">
+  <%= link_to_unless current_page.last?, t('views.pagination.last').html_safe, url, remote: remote %>
+</span>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -1,0 +1,11 @@
+<%# Link to the "Next" page
+  - available local variables
+    url:           url to the next page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="next">
+  <%= link_to_unless current_page.last?, t('views.pagination.next').html_safe, url, class: "join-item btn", rel: 'next', remote: remote %>
+</span>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -1,0 +1,11 @@
+<%# Link showing page number
+  - available local variables
+    page:          a page object for "this" page
+    url:           url to this page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+
+<%= link_to page, url, class: "join-item btn #{'btn-active' if page.current?}", remote: true, rel: page.rel %>

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -1,0 +1,28 @@
+<%# The container tag
+  - available local variables
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+    paginator:     the paginator that renders the pagination tags inside
+-%>
+
+<div class="join text-xs mt-8 mx-auto flex justify-center">
+  <%= paginator.render do %>
+    <nav class="pagination" role="navigation" aria-label="pager">
+      <%# 現在のページが最初のページでない場合のみ「最初のページ」と「前のページ」へのリンクを表示 %>
+      <%= prev_page_tag unless current_page.first? %>
+
+      <% each_page do |page| -%>
+        <%# 表示すべきページ番号の場合true %>
+        <% if page.display_tag? %>
+          <%# page_tagヘルパーでそのページへのリンクを生成 %>
+          <%= page_tag page %>
+        <% end %>
+      <% end %>
+
+      <%# 現在のページが最後のページでない場合のみ「次のページ」と「最後のページ」へのリンクを表示 %>
+      <%= next_page_tag unless current_page.last? %>
+    </nav>
+  <% end %>
+</div>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -1,0 +1,11 @@
+<%# Link to the "Previous" page
+  - available local variables
+    url:           url to the previous page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="prev">
+  <%= link_to_unless current_page.first?, t('views.pagination.previous').html_safe, url, class: "join-item btn", rel: 'prev', remote: remote %>
+</span>

--- a/app/views/mypages/show.html.erb
+++ b/app/views/mypages/show.html.erb
@@ -1,23 +1,55 @@
 <div class="flex flex-col min-h-screen bg-base-100">
-  <div class="p-10 bg-base-100 rounded-lg text-secondary">
-    <h2 class="text-2xl text-text-color mb-8"><%= t('.title')%></h2>
+  <div class="p-10 bg-base-100">
+    <div class="bg-primary rounded-lg text-secondary">
+      <div class="flex flex-col p-10">
 
-    <table class="table">
-      <tr>
-        <th scope="row"><%= User.human_attribute_name(:email) %> </th>
-        <td><%= current_user.email %></td>
-      </tr>
-      <tr>
-        <th scope="row"><%= User.human_attribute_name(:name) %></th>
-        <td><%= current_user.name %></td>
-      </tr>
-    </table>
 
-    <div class="flex justify-center py-10">
-      <button class="btn btn-primary text-secondary m-5">
-        <%= link_to "編集", edit_mypage_path %>
-      </button>
+      <h1 class="text-3xl font-bold mb-10"><%= t('.title') %></h1>
+
+      <table class="table-auto w-5/6 border-collapse ml-10">
+        <tr>
+          <th scope="row" class="text-left"><%= User.human_attribute_name(:email) %></th>
+          <td class="text-left"><%= current_user.email %></td>
+        </tr>
+        <tr>
+          <th scope="row" class="text-left"><%= User.human_attribute_name(:name) %></th>
+          <td class="text-left"><%= current_user.name %></td>
+        </tr>
+      </table>
+
+      <div class="flex justify-center py-10">
+        <button class="btn btn-bg-base-100 text-secondary m-5">
+          <%= link_to "編集", edit_mypage_path %>
+        </button>
+      </div>
+
+      <!-- クイズ回答履歴表示部分 -->
+      <h2 class="text-xl font-bold mb-4">クイズ回答履歴</h2>
+      <table class="table-auto w-full border-collapse border border-gray-200">
+        <thead>
+          <tr class="bg-white text-lg">
+            <th class="border border-gray-300 py-5">日時</th>
+            <th class="border border-gray-300 py-5">地点1</th>
+            <th class="border border-gray-300 py-5">地点2</th>
+            <th class="border border-gray-300 py-5">結果</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% @quiz_histories.each do |history| %>
+            <tr class="bg-base-100">
+              <td class="border border-gray-300 px-4 py-2 text-center"><%= history.answered_at.strftime('%Y-%m-%d') %></td>
+              <td class="border border-gray-300 px-4 py-2"><%= history.location1.name %></td>
+              <td class="border border-gray-300 px-4 py-2"><%= history.location2.name %></td>
+              <td class="border border-gray-300 px-4 py-2 text-center"><%= history.is_correct ? '正解' : '不正解' %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+      <%# ページネーション %>
+      <div class="flex flex-row justify-center py-10">
+        <%= paginate @quiz_histories %>
+      </div>
+
     </div>
-
   </div>
 </div>

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+Kaminari.configure do |config|
+  config.default_per_page = 20 # 1ページあたりの表示件数
+  # config.max_per_page = nil
+  config.window = 2 # 現在のページ＋前後何ページ表示するか
+  # config.outer_window = 0
+  # config.left = 0
+  # config.right = 0
+  # config.page_method_name = :page
+  # config.param_name = :page
+  # config.max_pages = nil
+  # config.params_on_first_page = false
+end

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -1,4 +1,11 @@
 ja:
+  views:
+    pagination:
+      first: <i class="fas fa-angle-double-left"></i>
+      last: <i class="fas fa-angle-double-right"></i>
+      previous: <i class="fas fa-angle-left"></i>
+      next: <i class="fas fa-angle-right"></i>
+      truncate: "..."
   helpers:
     # フォーム入力後の送信ボタン
     submit:


### PR DESCRIPTION
# 概要
クイズ履歴の表示

## 実装内容
- マイページに回答履歴を表示
- ページネーションを設定
  - Gem ‘kaminari’を追加
  - kaminariの設定を追加

## 達成条件
- [x] マイページにクイズの履歴が表示される
- [x] ページネーションが表示される

## 備考
### 実装メモ
[Notion](https://www.notion.so/114c61db530f8060831dff1aae7b186b?pvs=4)

closed #132