### PR TITLE
add:マイページに正答の距離を表示

### DIFF
--- a/app/controllers/challenge_mode/quizzes_controller.rb
+++ b/app/controllers/challenge_mode/quizzes_controller.rb
@@ -85,8 +85,8 @@ module ChallengeMode
         user_id: @current_user.id,
         location1_id: @locations[0].id,
         location2_id: @locations[1].id,
-        user_answer: @selected_choice,
-        correct_answer: @correct_answer,
+        user_answer: @selected_choice.to_i,
+        correct_answer: @correct_answer.to_i,
         is_correct: is_correct,
         mode: 'challenge_10'
       )

--- a/app/controllers/concerns/quiz_utils.rb
+++ b/app/controllers/concerns/quiz_utils.rb
@@ -17,7 +17,7 @@ module QuizUtils
 
     # セッションに保存
     session[:locations] = @locations.map(&:id)
-    session[:correct_answer] = @distance
+    session[:correct_answer] = @distance.to_i
     session[:choices] = @choices
   end
 
@@ -36,7 +36,7 @@ module QuizUtils
 
     # APIから帰ってきたdataから必要な情報を取り出し、単位kmに変換する
     distance_in_km = data['rows'][0]['elements'][0]['distance']['value'] / 1000.0
-    distance_in_km.round(1)
+    distance_in_km.round.to_i
   end
 
 

--- a/app/controllers/simple_mode/quizzes_controller.rb
+++ b/app/controllers/simple_mode/quizzes_controller.rb
@@ -38,8 +38,8 @@ module SimpleMode
           user_id: @current_user.id,
           location1_id: @locations[0].id,
           location2_id: @locations[1].id,
-          user_answer: @selected_choice,
-          correct_answer: @correct_answer,
+          user_answer: @selected_choice.to_i,
+          correct_answer: @correct_answer.to_i,
           is_correct: @selected_choice == @correct_answer,
           mode: 'simple'
         )

--- a/app/views/mypages/show.html.erb
+++ b/app/views/mypages/show.html.erb
@@ -30,6 +30,7 @@
             <th class="border border-gray-300 py-2">日時</th>
             <th class="border border-gray-300 py-2">START</th>
             <th class="border border-gray-300 py-2">GOAL</th>
+            <th class="border border-gray-300 py-2">距離</th>
             <th class="border border-gray-300 py-2">結果</th>
           </tr>
         </thead>
@@ -39,6 +40,7 @@
               <td class="border border-gray-300 px-4 py-1 text-center"><%= history.created_at.strftime('%Y-%m-%d') %></td>
               <td class="border border-gray-300 px-4 py-1"><%= history.location1.name %></td>
               <td class="border border-gray-300 px-4 py-1"><%= history.location2.name %></td>
+              <td class="border border-gray-300 text-center px-4 py-1"><%= number_with_delimiter(history.correct_answer.to_i) %></td>
               <td class="border border-gray-300 px-4 py-1 text-center"><%= history.is_correct ? '正解' : '不正解' %></td>
             </tr>
           <% end %>


### PR DESCRIPTION
# 概要
add:マイページに正答の距離を表示

## 実装内容
- マイページの回答履歴に正答の距離を追加
- 小数点以下は切り捨てて整数で表示されるよう設定

## 達成条件
- [x] マイページの回答履歴に正答の距離が整数で表示される

## 備考
### 実装メモ
[Notion](https://www.notion.so/11cc61db530f809b9226c1e0c20be02d?pvs=4)


closed #142 