### PR TITLE
add:クイズに地図の表示を追加

### DIFF
--- a/app/controllers/challenge_mode/quizzes_controller.rb
+++ b/app/controllers/challenge_mode/quizzes_controller.rb
@@ -31,8 +31,12 @@ module ChallengeMode
       @locations = Location.order('RANDOM()').limit(2)
 
       # Javascriptに渡せるように設定
-      gon.location1 = @locations[0]  # 地点1
-      gon.location2 = @locations[1]  # 地点2
+      ## 地点1
+      gon.latitude1 = @locations[0].latitude
+      gon.longitude1 = @locations[0].longitude
+      ## 地点2
+      gon.latitude2 = @locations[1].latitude
+      gon.longitude2 = @locations[1].longitude
 
       # calculate_distanceのメソッドに対して上記で取得した2地点を引数として渡す
       @distance = calculate_distance(@locations[0], @locations[1])

--- a/app/controllers/concerns/quiz_utils.rb
+++ b/app/controllers/concerns/quiz_utils.rb
@@ -5,13 +5,13 @@ module QuizUtils
     # ランダムに並び替え、そのうち2件を取得する
     @locations = Location.order('RANDOM()').limit(2)
 
-      # JavaScriptに渡せるように設定
-      ## 地点1
-      gon.latitude1 = @locations[0].latitude
-      gon.longitude1 = @locations[0].longitude
-      ## 地点2
-      gon.latitude2 = @locations[1].latitude
-      gon.longitude2 = @locations[1].longitude
+    # JavaScriptに渡せるように設定
+    ## 地点1
+    gon.latitude1 = @locations[0].latitude
+    gon.longitude1 = @locations[0].longitude
+    ## 地点2
+    gon.latitude2 = @locations[1].latitude
+    gon.longitude2 = @locations[1].longitude
 
     # calculate_distanceのメソッドに対して上記で取得した2地点を引数として渡す
     @distance = calculate_distance(@locations[0], @locations[1])

--- a/app/controllers/concerns/quiz_utils.rb
+++ b/app/controllers/concerns/quiz_utils.rb
@@ -5,9 +5,13 @@ module QuizUtils
     # ランダムに並び替え、そのうち2件を取得する
     @locations = Location.order('RANDOM()').limit(2)
 
-    # Javascriptに渡せるように設定
-    gon.location1 = @locations[0]  # 地点1
-    gon.location2 = @locations[1]  # 地点2
+      # JavaScriptに渡せるように設定
+      ## 地点1
+      gon.latitude1 = @locations[0].latitude
+      gon.longitude1 = @locations[0].longitude
+      ## 地点2
+      gon.latitude2 = @locations[1].latitude
+      gon.longitude2 = @locations[1].longitude
 
     # calculate_distanceのメソッドに対して上記で取得した2地点を引数として渡す
     @distance = calculate_distance(@locations[0], @locations[1])

--- a/app/javascript/map.js
+++ b/app/javascript/map.js
@@ -1,5 +1,12 @@
 // 地図の初期化
 function initMap(){
+  // Google Maps APIが読み込まれているか確認
+  if (typeof google.maps === 'undefined') {
+    window.alert('APIの準備ができていません。');
+    setTimeout(initMap, 500);
+    return;
+  }
+
   const directionsService = new google.maps.DirectionsService();  // 指定された出発地点から到着地点までの経路情報を取得するサービス
   const directionsRenderer = new google.maps.DirectionsRenderer();  // 取得した経路情報を地図上に表示するためのレンダラー
   const map = new google.maps.Map(document.getElementById("map"), {
@@ -31,4 +38,7 @@ function calculateAndDisplayRoute(directionsService, directionsRenderer) {
     .catch((e) => window.alert("Directions request failed due to " + e));  // 失敗した時にエラー内容をアラートで表示
 }
 
-initMap();
+// ページが完全にロードされてinitMapを実行
+window.onload = function() {
+  initMap();
+};

--- a/app/views/challenge_mode/quizzes/new.html.erb
+++ b/app/views/challenge_mode/quizzes/new.html.erb
@@ -1,13 +1,13 @@
-<div class="flex flex-col min-h-screen bg-base-100">
-  <div class="p-10 bg-base-100">
-    <div class="bg-primary rounded-lg text-secondary">
+<div class="flex flex-col h-screen bg-base-100 p-10">
+  <div class="bg-primary rounded-lg text-secondary flex-1 flex flex-col">
+    <div class="flex flex-col p-10 flex-1">
 
-      <div class="flex flex-col justify-center items-center px-10 pb-10">
-        <h2 class="text-3xl font-bold p-20"><%= session[:challenge_mode][:current_question] %> / <%= session[:challenge_mode][:question_count] %>問目</h2>
+      <div class="flex flex-col justify-center items-center">
+        <h2 class="text-3xl font-bold pb-5"><%= session[:challenge_mode][:current_question] %> / <%= session[:challenge_mode][:question_count] %>問目</h2>
         <p class="text-base"><span class="text-lg font-bold"><%= @locations[0].name %></span>から<span class="text-lg font-bold"><%= @locations[1].name %></span>までの距離は何kmあるでしょう？</p>
       </div>
 
-      <div class="flex flex-row justify-center px-10 pt-5 pb-20 m-8">
+      <div class="flex flex-row justify-center px-10 pt-2 pb-3">
         <div id="choices">
           <%= form_with url: answer_challenge_mode_quizzes_path, method: :get, local: true do %>
             <% @choices.each do |choice| %>
@@ -18,6 +18,21 @@
           <% end %>
         </div>
       </div>
+
+      <!-- Google Maps API を読み込む -->
+      <script src="https://maps.googleapis.com/maps/api/js?key=<%= "#{ENV['MAPS_JAVASCRIPT_API']}" %>&language=ja&callback=initMap" async defer></script>
+
+      <div class="flex justify-center flex-1">
+        <div class="flex bg-primary rounded-lg text-secondary w-full">
+          <div class="flex flex-col m-3 p-3 bg-white w-full h-full">
+            <p class="text-base font-bold mb-2">ルート</p>
+            <div id="map" class="flex-1 w-full" style="height: 400px width: auto;"></div>
+          </div>
+        </div>
+      </div>
+
+      <!-- 外部ファイルからJavaScriptを読み込み -->
+      <%= javascript_include_tag 'map.js' %>
 
     </div>
   </div>

--- a/app/views/simple_mode/quizzes/new.html.erb
+++ b/app/views/simple_mode/quizzes/new.html.erb
@@ -1,12 +1,12 @@
-<div class="flex flex-col min-h-screen bg-base-100">
-  <div class="p-10 bg-base-100">
-    <div class="bg-primary rounded-lg text-secondary">
+<div class="flex flex-col h-screen bg-base-100 p-10">
+  <div class="bg-primary rounded-lg text-secondary flex-1 flex flex-col">
+    <div class="flex flex-col p-10 flex-1">
 
-      <div class="flex flex-col justify-center items-center px-10 pt-20 pb-10">
+      <div class="flex flex-col justify-center items-center">
         <p class="text-base"><span class="text-lg font-bold"><%= @locations[0].name %></span>から<span class="text-lg font-bold"><%= @locations[1].name %></span>までの距離は何kmあるでしょう？</p>
       </div>
 
-      <div class="flex flex-row justify-center px-10 pt-5 pb-20 m-8">
+      <div class="flex flex-row justify-center px-10 py-5">
         <div id="choices">
           <%= form_with url: answer_simple_mode_quizzes_path, method: :get, local: true do %>
             <% @choices.each do |choice| %>
@@ -17,6 +17,21 @@
           <% end %>
         </div>
       </div>
+
+      <!-- Google Maps API を読み込む -->
+      <script src="https://maps.googleapis.com/maps/api/js?key=<%= "#{ENV['MAPS_JAVASCRIPT_API']}" %>&language=ja&callback=initMap" async defer></script>
+
+      <div class="flex justify-center flex-1">
+        <div class="flex bg-primary rounded-lg text-secondary w-full">
+          <div class="flex flex-col m-3 p-3 bg-white w-full h-full">
+            <p class="text-base font-bold mb-2">ルート</p>
+            <div id="map" class="flex-1 w-full" style="height: 400px width: auto;"></div>
+          </div>
+        </div>
+      </div>
+
+      <!-- 外部ファイルからJavaScriptを読み込み -->
+      <%= javascript_include_tag 'map.js' %>
 
     </div>
   </div>

--- a/app/views/simple_mode/quizzes/show.html.erb
+++ b/app/views/simple_mode/quizzes/show.html.erb
@@ -5,7 +5,7 @@
       <h2 class="text-5xl font-semibold text-center mb-5"><%= @result %></h2>
 
       <div class="bg-primary rounded-lg text-secondary mb-1">
-        <div class="flex flex-row px-10 pt-5">
+        <div class="flex flex-row justify-center items-center px-10 pt-5">
           <p class="text-base"><span class="text-lg font-bold"><%= @locations[0].name %></span>から<span class="text-lg font-bold"><%= @locations[1].name %></span>までの距離は<span class="text-lg font-bold">約<%= @correct_answer %> km</span>です。</p>
         </div>
       </div>
@@ -17,7 +17,7 @@
         <div class="flex bg-primary rounded-lg text-secondary w-full">
           <div class="flex flex-col m-3 p-3 bg-white w-full h-full">
             <p class="text-base font-bold mb-2">ルート</p>
-            <div id="map" class="flex-1 w-full" style="height: 100%; width: 100%;"></div>
+            <div id="map" class="flex-1 w-full" style="height: 400px width: auto;"></div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
# 概要
クイズに地図の表示を追加

## 実装内容
- 各モードのnewアクションに地図の表示のためのコードを追加
- ビューに地図の表示を追加
- 地図の表示に伴うレイアウトの調整

## 達成条件
- [x] クイズの出題時に地図が表示される

## 備考
closed #147

- CI環境でのテストで問題が発生したため、次のブランチでテストコードの変更対応をする