### PR TITLE
ページごとのログイン要否の設定

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,6 @@
 class ApplicationController < ActionController::Base
+  # 各ページのログイン要否の設定に必要
+  before_action :require_login
   add_flash_types :success, :danger, :alert
 
   private

--- a/app/controllers/challenge_mode/quizzes_controller.rb
+++ b/app/controllers/challenge_mode/quizzes_controller.rb
@@ -4,9 +4,7 @@ module ChallengeMode
     # QuizUtilsモジュール（calculate_distanceメソッド、generate_choicesメソッド）
     include QuizUtils
 
-    # ログイン必須
-    before_action :require_login, only: %i[show new result start]
-    # ログイン不要
+    # ログイン不要（rankingのみ）
     skip_before_action :require_login, only: %i[ranking]
 
     def start;end

--- a/app/controllers/mypages_controller.rb
+++ b/app/controllers/mypages_controller.rb
@@ -1,5 +1,7 @@
 class MypagesController < ApplicationController
+  # ログイン中のユーサー情報をセット
   before_action :set_user
+
 
   def show
     @quiz_histories = current_user.quiz_histories.includes(:location1, :location2)

--- a/app/controllers/simple_mode/quizzes_controller.rb
+++ b/app/controllers/simple_mode/quizzes_controller.rb
@@ -4,9 +4,11 @@ module SimpleMode
     # QuizUtilsモジュール（calculate_distanceメソッド、generate_choicesメソッド）
     include QuizUtils
 
+    # ログイン不要
+    skip_before_action :require_login
+
     # ログインしている場合にのみユーザーをセットする
     before_action :set_user_if_logged_in
-
 
     def new
       # ランダムに並び替え、そのうち2件を取得する

--- a/app/controllers/tops_controller.rb
+++ b/app/controllers/tops_controller.rb
@@ -1,3 +1,5 @@
 class TopsController < ApplicationController
+  # ログイン不要
+  skip_before_action :require_login
   def index; end
 end

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -1,5 +1,6 @@
 class UserSessionsController < ApplicationController
-  # skip_before_action :require_login, only: %i[new create]
+  # ユーザーがログインしていなくてもログインページにアクセスできるように設定
+  skip_before_action :require_login, only: %i[new create]
 
   def new; end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,6 @@
 class UsersController < ApplicationController
   # ユーザーがログインしていなくても新規登録ページにアクセスできるように設定
-  # skip_before_action :require_login, only: %i[new create]
+  skip_before_action :require_login, only: %i[new create]
 
   # 新規ユーザーの登録フォームを表示するためのアクション
   def new


### PR DESCRIPTION
# 概要
ページごとのログイン要否の設定

## 実装内容
- applicationコントローラーに設定を追加
- 各コントローラーに設定を追加

## 達成条件
- [x] ログインしていない状態でログインが必要なページに遷移しようとすると、ログインページへリダイレクト
- [x]  ログインしていない状態でログイン不要のページに正しく遷移する

## 備考
### 実装メモ
[Notion](https://www.notion.so/127c61db530f80888a10f87878a1030d?pvs=4)

closed #160