### PR TITLE
add:回答履歴に地図の表示を追加

### DIFF
--- a/app/controllers/mypages_controller.rb
+++ b/app/controllers/mypages_controller.rb
@@ -2,7 +2,6 @@ class MypagesController < ApplicationController
   # ログイン中のユーサー情報をセット
   before_action :set_user
 
-
   def show
     @quiz_histories = current_user.quiz_histories.includes(:location1, :location2)
                                   .order(created_at: :desc)
@@ -21,6 +20,18 @@ class MypagesController < ApplicationController
     end
   end
 
+  def map_view
+    # 受け取った履歴IDを取得
+    @history = current_user.quiz_histories.find(params[:id])
+
+    # 履歴詳細から地点情報を取得
+    location1 = @history.location1
+    location2 = @history.location2
+
+    # 地点情報の緯度・経度をgon変数にセット
+    set_gon_locations(location1, location2)
+  end
+
   private
 
   def set_user
@@ -30,4 +41,12 @@ class MypagesController < ApplicationController
   def user_params
     params.require(:user).permit(:email, :name)
   end
+
+  def set_gon_locations(location1, location2)
+    gon.latitude1 = location1.latitude
+    gon.longitude1 = location1.longitude
+    gon.latitude2 = location2.latitude
+    gon.longitude2 = location2.longitude
+  end
+
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -33,8 +33,8 @@
       <%= render 'shared/flash_message' %>
       <%= yield %>
     </div>
-    <!-- quizzes コントローラーの new または show アクションでのみ Google Maps API を読み込む -->
-    <% if controller_name == "quizzes" && (action_name == "new" || action_name == "show") %>
+    <!-- quizzes コントローラーの new または show アクション、mypagesコントローラーの map_view アクションでのみ Google Maps API を読み込む -->
+    <% if (controller_name == "quizzes" && (action_name == "new" || action_name == "show")) || (controller_name == "mypages" && action_name == "map_view") %>
       <script src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['MAPS_JAVASCRIPT_API'] %>&language=ja&callback=initMap" async defer></script>
       <%= javascript_include_tag 'map.js' %>
     <% end %>

--- a/app/views/mypages/map_view.html.erb
+++ b/app/views/mypages/map_view.html.erb
@@ -1,0 +1,30 @@
+<div class="flex flex-col h-screen bg-base-100 p-10">
+  <div class="bg-primary rounded-lg text-secondary flex-1 flex flex-col">
+    <div class="flex flex-col p-10 flex-1">
+
+      <div class="bg-primary rounded-lg text-secondary mb-1">
+        <div class="flex flex-row justify-center items-center px-10 pt-5">
+          <p class="text-base"><span class="text-lg font-bold"><%= @history.location1.name %></span>
+                                                              から
+                                                              <span class="text-lg font-bold"><%= @history.location2.name %></span>
+                                                              までの距離：
+                                                              <span class="text-lg font-bold">約<%= number_with_delimiter(@history.correct_answer.to_i)%>km</span></p>
+        </div>
+      </div>
+
+      <div class="flex justify-center flex-1">
+        <div class="flex bg-primary rounded-lg text-secondary w-full">
+          <div class="flex flex-col m-3 p-3 bg-white w-full h-full">
+            <p class="text-base font-bold mb-2">ルート</p>
+            <div id="map" class="flex-1 w-full" style="height: 400px width: auto;"></div>
+          </div>
+        </div>
+      </div>
+
+      <div class="flex flex-row justify-center px-10">
+        <%= link_to '履歴一覧に戻る', mypage_path, class: 'btn text-base-100 font-bold bg-secondary mt-10' %>
+      </div>
+
+    </div>
+  </div>
+</div>

--- a/app/views/mypages/show.html.erb
+++ b/app/views/mypages/show.html.erb
@@ -32,6 +32,7 @@
             <th class="border border-gray-300 py-2">GOAL</th>
             <th class="border border-gray-300 py-2">距離</th>
             <th class="border border-gray-300 py-2">結果</th>
+            <th class="border border-gray-300 py-2">地図</th>
           </tr>
         </thead>
         <tbody>
@@ -42,6 +43,11 @@
               <td class="border border-gray-300 px-4 py-1"><%= history.location2.name %></td>
               <td class="border border-gray-300 text-center px-4 py-1"><%= number_with_delimiter(history.correct_answer.to_i) %></td>
               <td class="border border-gray-300 px-4 py-1 text-center"><%= history.is_correct ? '正解' : '不正解' %></td>
+              <td class="border border-gray-300 px-4 py-1 text-center">
+                <a href="<%= mypages_map_view_path(id: history.id) %>" class="text-2xl">
+                  <i class="fa-solid fa-map-location-dot"></i>
+                </a>
+              </td>
             </tr>
           <% end %>
         </tbody>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,7 +44,7 @@ Rails.application.routes.draw do
     get 'ranking', to: 'quizzes#ranking'
   end
 
-  # プロフィール
+  # プロフィール、回答履歴
   resource :mypage, only: %i[show edit update]
-
+  get "mypages/map_view" => "mypages#map_view"
 end


### PR DESCRIPTION
# 概要
回答履歴に地図の表示を追加

## 実装内容
- ルーティングの追加
- mypageコントローラーにmap_viewアクションを追加
- 既存のビューの変更
- 地図表示用のビューの追加
- application.html.erbに設定を追加

## 達成条件
- [x] 回答履歴の地図アイコンをクリックすると、対象のクイズの地図表示画面に遷移する


## 備考
### 実装メモ
[Notion](https://www.notion.so/128c61db530f80bf98b0f3e3475e8d6e?pvs=4)

closed #144