### PR TITLE
新規ユーザー登録後そのままログインする

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -11,6 +11,7 @@ class UsersController < ApplicationController
   def create
     @user = User.new(user_params)
     if @user.save
+      auto_login(@user)
       flash[:success] = t('.success')
       redirect_to root_path
     else


### PR DESCRIPTION
# 概要
新規ユーザー登録後そのままログインする

## 実装内容
- userコントローラーに、auto_loginメソッドを追加

## 達成条件
- [x] ユーザー登録後、そのままログイン状態を保持する

## 備考
### 実装メモ
closed #93