### PR TITLE
change:ランキング表示順の調整

### DIFF
--- a/app/controllers/challenge_mode/quizzes_controller.rb
+++ b/app/controllers/challenge_mode/quizzes_controller.rb
@@ -106,7 +106,7 @@ module ChallengeMode
       # 上位20名のランキングを取得
       @rankings = ChallengeResult
                   .includes(:user) # N+1 問題を防ぐため、ユーザー情報を一括取得
-                  .order(correct_answers: :desc, created_at: :asc) # 正答数の降順に並べ替え
+                  .order(correct_answers: :desc, created_at: :desc) # 正答数の降順に並べ替え
                   .limit(20) # 上位20名を表示
 
       # 今回の挑戦が20位以内にランクインしているか確認。trueかfalseを代入


### PR DESCRIPTION
# 修正概要
結果画面のランキング表示順を調整

## 修正詳細
- 結果画面のランキングが同率順位の時の表示順を変更
  - 古い日付が上位にに表示される設定　→　新しい日付が上位に表示される設定