### PR TITLE
fix:交通手段の選択がmap1とmap2で連動してしまう不具合を修正

### DIFF
--- a/app/views/compare_maps/new.html.erb
+++ b/app/views/compare_maps/new.html.erb
@@ -21,15 +21,15 @@
           <%= f.label :"交通手段", class: "form-label text-sm md:text-base mb-2" %>
           <ul class="flex gap-14">
             <li>
-              <%= f.radio_button :travelMode, 'DRIVING', checked: true, id: "travel-driving", class: "hidden peer" %>
-              <label for="travel-driving" class="flex flex-col items-center justify-center w-16 h-16 text-secondary bg-primary rounded-lg cursor-pointer peer-checked:bg-secondary peer-checked:text-white">
+              <%= f.radio_button :travelMode, 'DRIVING', checked: true, id: "travel-driving1", class: "hidden peer" %>
+              <label for="travel-driving1" class="flex flex-col items-center justify-center w-16 h-16 text-secondary bg-primary rounded-lg cursor-pointer peer-checked:bg-secondary peer-checked:text-white">
                 <i class="fa-solid fa-car text-2xl"></i>
                 <span class="text-sm mt-1">車</span>
               </label>
             </li>
             <li>
-              <%= f.radio_button :travelMode, 'WALKING', id: "travel-walking", class: "hidden peer" %>
-              <label for="travel-walking" class="flex flex-col items-center justify-center w-16 h-16 text-secondary bg-primary rounded-lg cursor-pointer peer-checked:bg-secondary peer-checked:text-white">
+              <%= f.radio_button :travelMode, 'WALKING', id: "travel-walking1", class: "hidden peer" %>
+              <label for="travel-walking1" class="flex flex-col items-center justify-center w-16 h-16 text-secondary bg-primary rounded-lg cursor-pointer peer-checked:bg-secondary peer-checked:text-white">
                 <i class="fa-solid fa-person-walking text-2xl"></i>
                 <span class="text-sm mt-1">徒歩</span>
               </label>
@@ -97,15 +97,15 @@
           <%= f.label :"交通手段", class: "form-label text-sm md:text-base mb-2" %>
           <ul class="flex gap-14">
             <li>
-              <%= f.radio_button :travelMode, 'DRIVING', checked: true, id: "travel-driving", class: "hidden peer" %>
-              <label for="travel-driving" class="flex flex-col items-center justify-center w-16 h-16 text-secondary bg-primary rounded-lg cursor-pointer peer-checked:bg-secondary peer-checked:text-white">
+              <%= f.radio_button :travelMode, 'DRIVING', checked: true, id: "travel-driving2", class: "hidden peer" %>
+              <label for="travel-driving2" class="flex flex-col items-center justify-center w-16 h-16 text-secondary bg-primary rounded-lg cursor-pointer peer-checked:bg-secondary peer-checked:text-white">
                 <i class="fa-solid fa-car text-2xl"></i>
                 <span class="text-sm mt-1">車</span>
               </label>
             </li>
             <li>
-              <%= f.radio_button :travelMode, 'WALKING', id: "travel-walking", class: "hidden peer" %>
-              <label for="travel-walking" class="flex flex-col items-center justify-center w-16 h-16 text-secondary bg-primary rounded-lg cursor-pointer peer-checked:bg-secondary peer-checked:text-white">
+              <%= f.radio_button :travelMode, 'WALKING', id: "travel-walking2", class: "hidden peer" %>
+              <label for="travel-walking2" class="flex flex-col items-center justify-center w-16 h-16 text-secondary bg-primary rounded-lg cursor-pointer peer-checked:bg-secondary peer-checked:text-white">
                 <i class="fa-solid fa-person-walking text-2xl"></i>
                 <span class="text-sm mt-1">徒歩</span>
               </label>


### PR DESCRIPTION
# 修正概要
交通手段の選択がmap1とmap2で連動してしまう不具合を修正

## 修正詳細
- 交通手段`travelMode`のidを各フォームでユニークになるよう設定

closed #178