### PR TITLE
fix:トップページのリンクの不備を修正

### DIFF
--- a/app/views/tops/index.html.erb
+++ b/app/views/tops/index.html.erb
@@ -58,7 +58,7 @@
 
         <div class="flex justify-end mr-10">
           <button class="btn btn-neutral bg-base-100 text-secondary text-sm lg:text-base ml-5 mb-1 w-60">
-            <%= link_to "地図比較ツール", compare_maps_path %>
+            <%= link_to "地図比較ツール", new_compare_map_path %>
           </button>
         </div>
       </div>


### PR DESCRIPTION
# 修正概要
トップページのリンクの不備を修正

## 修正詳細
- トップページの地図比較ページへのリンクが正しく設定されていなかったため修正

closed #182